### PR TITLE
fixed import of deprecated formtools

### DIFF
--- a/cbv_formpreview/preview.py
+++ b/cbv_formpreview/preview.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 from django.utils.crypto import constant_time_compare
-from django.contrib.formtools.utils import form_hmac
+try:
+    from django.contrib.formtools.utils import form_hmac
+except ImportError:
+    from formtools.utils import form_hmac
 from django.views.generic import FormView
 
 PREVIEW_STAGE = 'preview'


### PR DESCRIPTION
formtools is moved out from Django core starting from version 1.8. This pull request fixes import statement to support the latest Django.
